### PR TITLE
Features/add-allowed-mime-types

### DIFF
--- a/allow-models-upload.php
+++ b/allow-models-upload.php
@@ -13,6 +13,7 @@
 
 add_filter('upload_mimes', function($mime_types) {
     $mime_types['gltf'] = 'model/gltf+json';
+    $mime_types['glb'] = 'model/gltf-binary';
 
     return $mime_types;
 });
@@ -26,6 +27,11 @@ add_filter('wp_check_filetype_and_ext', function($data, $file, $filename, $mime_
         if ('gltf' === $file_type['ext']) {
             $data['ext']  = 'gltf';
             $data['type'] = 'model/gltf+json';
+        }
+
+        if ('glb' === $file_type['ext']) {
+            $data['ext']  = 'glb';
+            $data['type'] = 'model/glb-binary';
         }
     }
 

--- a/allow-models-upload.php
+++ b/allow-models-upload.php
@@ -10,3 +10,24 @@
  * Requires at least:   5.9
  * Requires PHP:        7.4
  */
+
+add_filter('upload_mimes', function($mime_types) {
+    $mime_types['gltf'] = 'model/gltf+json';
+
+    return $mime_types;
+});
+
+add_filter('wp_check_filetype_and_ext', function($data, $file, $filename, $mime_types, $real_mime_type) {
+    if (empty($data['ext'])
+        || empty($data['type'])
+    ) {
+        $file_type = wp_check_filetype($filename, $mime_types);
+
+        if ('gltf' === $file_type['ext']) {
+            $data['ext']  = 'gltf';
+            $data['type'] = 'model/gltf+json';
+        }
+    }
+
+    return $data;
+}, 10, 5);


### PR DESCRIPTION
Added `.gltf` and `.glb` mime types to be uploaded into WordPress Media Library.